### PR TITLE
Add build-scf pipeline

### DIFF
--- a/pipelines/scf-build-deploy/pipeline.yml
+++ b/pipelines/scf-build-deploy/pipeline.yml
@@ -6,7 +6,7 @@ resources:
   check_every: 60m
   source:
     uri: https://github.com/SUSE/scf.git
-    branch: 2.14.3
+    branch: 2.14.5
     git_config:
     - name: submodule.fetchJobs
       value: 128

--- a/pipelines/scf-build-deploy/pipeline.yml
+++ b/pipelines/scf-build-deploy/pipeline.yml
@@ -1,0 +1,64 @@
+---
+resources:
+- name: scf-pub-github-repo
+  tags: [containerization]
+  type: git
+  check_every: 60m
+  source:
+    uri: https://github.com/SUSE/scf.git
+    branch: 2.14.3
+    git_config:
+    - name: submodule.fetchJobs
+      value: 128
+
+- name: scf-helm-charts
+  tags: [containerization]
+  type: s3
+  check_every: 5m
+  source:
+    disable_ssl: true
+    bucket: unique-bbuccket
+    endpoint: ((cos-endpoint))
+    regexp: scf-(.*)-helm.tar.gz
+    access_key_id: ((cos-access-key-id))
+    secret_access_key: ((cos-secret-access-key))
+
+jobs:
+- name: scf-build
+  plan:
+  - get: scf-pub-github-repo
+    tags: [containerization]
+    trigger: true
+    params: { submodules: all }
+  - task: scf-build
+    tags: [containerization]
+    privileged: true
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: havener/build-environment
+          tag: latest
+      inputs:
+      - name: scf-pub-github-repo
+      outputs:
+      - name: helm-chart-store
+      #
+      # WIP: need to define where exactly to push the images, our current IBM container registry will not have enough quota for amount of images.
+      # params:
+      #   REGISTRY_ENDPOINT: ((private-registry-hostname))
+      #   REGISTRY_USERNAME: ((private-registry-docker-username))
+      #   REGISTRY_PASSWORD_RW: ((private-registry-docker-password-read-write))
+      #   REGISTRY_PASSWORD_RO: ((private-registry-docker-password-read-only))
+      #   REGISTRY_NAMESPACE: ((private-registry-namespace))
+      run:
+        path: /bin/bash
+        args:
+        - -c
+        - (( file "scripts/build.sh" ))
+  - put: scf-helm-charts
+    tags: [cfee]
+    attempts: 5
+    params:
+      file: helm-chart-store/scf-*-helm.tar.gz

--- a/pipelines/scf-build-deploy/pipeline.yml
+++ b/pipelines/scf-build-deploy/pipeline.yml
@@ -44,21 +44,72 @@ jobs:
       - name: scf-pub-github-repo
       outputs:
       - name: helm-chart-store
-      #
-      # WIP: need to define where exactly to push the images, our current IBM container registry will not have enough quota for amount of images.
-      # params:
-      #   REGISTRY_ENDPOINT: ((private-registry-hostname))
-      #   REGISTRY_USERNAME: ((private-registry-docker-username))
-      #   REGISTRY_PASSWORD_RW: ((private-registry-docker-password-read-write))
-      #   REGISTRY_PASSWORD_RO: ((private-registry-docker-password-read-only))
-      #   REGISTRY_NAMESPACE: ((private-registry-namespace))
+      params:
+        # REGISTRY_ENDPOINT: "registry.hub.docker.com"
+        DOCKER_TEAM_USERNAME: ((dockerhub.username))
+        DOCKER_TEAM_PASSWORD_RW: ((dockerhub.password))
+        REGISTRY_NAMESPACE: "cfcontainerization"
       run:
         path: /bin/bash
         args:
         - -c
         - (( file "scripts/build.sh" ))
   - put: scf-helm-charts
-    tags: [cfee]
+    tags: [containerization]
     attempts: 5
     params:
       file: helm-chart-store/scf-*-helm.tar.gz
+
+- name: scf-deploy
+  plan:
+  - get: scf-helm-charts
+    tags: [containerization]
+    passed: [scf-build]
+    trigger: true
+  - task: scf-deploy
+    tags: [containerization]
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: havener/alpine-havener
+          tag: latest
+      inputs:
+      - name: scf-helm-charts
+      params:
+        BX_API: api.eu-gb.bluemix.net
+        BX_API_KEY: ((ibmcloud.key-value))
+        CLUSTER_NAME: pebbles01
+      run:
+        path: /bin/bash
+        args:
+        - -c
+        - (( file "scripts/deploy.sh" ))
+
+- name: scf-test
+  plan:
+  - get: scf-helm-charts
+    tags: [containerization]
+    passed: [scf-deploy]
+    trigger: true
+  - task: scf-test
+    tags: [containerization]
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: havener/alpine-havener
+          tag: latest
+      inputs:
+      - name: scf-helm-charts
+      params:
+        BX_API: api.eu-gb.bluemix.net
+        BX_API_KEY: ((ibmcloud.key-value))
+        CLUSTER_NAME: pebbles01
+      run:
+        path: /bin/bash
+        args:
+        - -c
+        - (( file "scripts/test.sh" ))

--- a/pipelines/scf-build-deploy/scripts/build.sh
+++ b/pipelines/scf-build-deploy/scripts/build.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+BASE_DIR="$(pwd)"
+
+# Start Docker Daemon (and set a trap to stop it once this script is done)
+echo 'DOCKER_OPTS="--data-root /scratch/docker --max-concurrent-downloads 10"' >/etc/default/docker
+service docker start
+service docker status
+trap 'service docker stop' EXIT
+sleep 10
+
+#
+# WIP: need to define where exactly to push the images, our current IBM container registry will not have enough quota for amount of images.
+# echo "${REGISTRY_PASSWORD_RW}" | docker login --username "${REGISTRY_USERNAME}" --password-stdin "${REGISTRY_ENDPOINT}"
+
+pushd scf-pub-github-repo
+source .envrc
+
+# Add safe-guard: We should only build images if the current fissile version
+# matched the one SUSE wants us to use for the respective SCF version in use.
+REQUIRED_FISSILE_VERSION=$(source ./bin/common/versions.sh && echo "${FISSILE_VERSION}")
+REQUIRED_FISSILE_COMMIT_SHA="$(grep -Eo '[A-Za-z0-9]{7}$' <<<"${REQUIRED_FISSILE_VERSION}")"
+echo "Required fissile version: ${REQUIRED_FISSILE_VERSION}"
+pushd "$(mktemp -d)" >/dev/null
+( mkdir -p src && \
+  export GOPATH=$PWD && \
+  export PATH="$PATH:$GOPATH/bin" && \
+  go get -d code.cloudfoundry.org/fissile || true && \
+  cd $GOPATH/src/code.cloudfoundry.org/fissile && \
+  git checkout "${REQUIRED_FISSILE_COMMIT_SHA}" && \
+  make tools docker-deps build && \
+  cp -p build/linux-amd64/fissile /usr/local/bin/fissile )
+popd >/dev/null
+echo "[INFO] fissile version: $(fissile version)"
+
+SCF_VERSION="$(git describe --tags)"
+
+make docker-deps
+#
+# WIP: need to define where exactly to push the images, our current IBM container registry will not have enough quota for amount of images.
+# export FISSILE_DOCKER_REGISTRY="${REGISTRY_ENDPOINT}"
+# export FISSILE_DOCKER_USERNAME="${REGISTRY_USERNAME}"
+# export FISSILE_DOCKER_PASSWORD="${REGISTRY_PASSWORD_RO}"
+# export FISSILE_DOCKER_ORGANIZATION="${REGISTRY_NAMESPACE}"
+
+make releases \
+  compile \
+  images
+popd
+
+echo "Process locally generated Helm Charts"
+HELM_TMP_DIR="$(mktemp --directory)"
+mkdir -p ${HELM_TMP_DIR}/kube ${HELM_TMP_DIR}/helm
+cp -rp scf-pub-github-repo/output/kube ${HELM_TMP_DIR}/kube/cf
+cp -rp scf-pub-github-repo/src/uaa-fissile-release/kube ${HELM_TMP_DIR}/kube/uaa
+cp -rp scf-pub-github-repo/output/helm ${HELM_TMP_DIR}/helm/cf
+cp -rp scf-pub-github-repo/src/uaa-fissile-release/helm ${HELM_TMP_DIR}/helm/uaa
+TARGET_TGZ="$(realpath helm-chart-store)/scf-${SCF_VERSION}-helm.tar.gz"
+pushd ${HELM_TMP_DIR}
+tar -czf ${TARGET_TGZ} helm kube
+popd
+
+#
+# WIP: need to define where exactly to push the images, our current IBM container registry will not have enough quota for amount of images.
+# echo "Pushing Docker images ..."
+# docker images --format "{{.Repository}}:{{.Tag}}" | grep "${REGISTRY_ENDPOINT}/${REGISTRY_NAMESPACE}" | while read -r DOCKER_IMAGE_AND_TAG; do
+#   docker push "${DOCKER_IMAGE_AND_TAG}"
+# done

--- a/pipelines/scf-build-deploy/scripts/build.sh
+++ b/pipelines/scf-build-deploy/scripts/build.sh
@@ -11,9 +11,7 @@ service docker status
 trap 'service docker stop' EXIT
 sleep 10
 
-#
-# WIP: need to define where exactly to push the images, our current IBM container registry will not have enough quota for amount of images.
-# echo "${REGISTRY_PASSWORD_RW}" | docker login --username "${REGISTRY_USERNAME}" --password-stdin "${REGISTRY_ENDPOINT}"
+echo "${DOCKER_TEAM_PASSWORD_RW}" | docker login --username "${DOCKER_TEAM_USERNAME}" --password-stdin
 
 pushd scf-pub-github-repo
 source .envrc
@@ -38,12 +36,11 @@ echo "[INFO] fissile version: $(fissile version)"
 SCF_VERSION="$(git describe --tags)"
 
 make docker-deps
-#
-# WIP: need to define where exactly to push the images, our current IBM container registry will not have enough quota for amount of images.
+
 # export FISSILE_DOCKER_REGISTRY="${REGISTRY_ENDPOINT}"
-# export FISSILE_DOCKER_USERNAME="${REGISTRY_USERNAME}"
-# export FISSILE_DOCKER_PASSWORD="${REGISTRY_PASSWORD_RO}"
-# export FISSILE_DOCKER_ORGANIZATION="${REGISTRY_NAMESPACE}"
+export FISSILE_DOCKER_USERNAME="${DOCKER_TEAM_USERNAME}"
+export FISSILE_DOCKER_PASSWORD="${DOCKER_TEAM_PASSWORD_RW}"
+export FISSILE_DOCKER_ORGANIZATION="${REGISTRY_NAMESPACE}"
 
 make releases \
   compile \
@@ -62,9 +59,8 @@ pushd ${HELM_TMP_DIR}
 tar -czf ${TARGET_TGZ} helm kube
 popd
 
-#
-# WIP: need to define where exactly to push the images, our current IBM container registry will not have enough quota for amount of images.
-# echo "Pushing Docker images ..."
-# docker images --format "{{.Repository}}:{{.Tag}}" | grep "${REGISTRY_ENDPOINT}/${REGISTRY_NAMESPACE}" | while read -r DOCKER_IMAGE_AND_TAG; do
-#   docker push "${DOCKER_IMAGE_AND_TAG}"
-# done
+echo "Pushing Docker images ..."
+docker images --format "{{.Repository}}:{{.Tag}}" | grep "${REGISTRY_NAMESPACE}/" | while read -r DOCKER_IMAGE_AND_TAG; do
+  docker push "${DOCKER_IMAGE_AND_TAG}"
+done
+  

--- a/pipelines/scf-build-deploy/scripts/deploy.sh
+++ b/pipelines/scf-build-deploy/scripts/deploy.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+set -euo pipefail
+
+bx login -a "${BX_API}" --apikey "${BX_API_KEY}"
+eval "$(bx cs cluster-config "${CLUSTER_NAME}" --export)"
+
+mkdir -p charts && tar -xzf scf-helm-charts/scf-*-helm.tar.gz -C charts
+cat <<'EOF' >armada-deploy.yml
+---
+name: armada
+releases:
+- chart_name: uaa
+  chart_namespace: uaa
+  chart_version: 0
+  chart_location: charts/helm/uaa
+  overrides:
+    secrets:
+      UAA_ADMIN_CLIENT_SECRET: MyUaaAdminClientSecret
+    env:
+      DOMAIN: (( shell bx cs cluster-get --cluster ${CLUSTER_NAME} --json | jq --raw-output .ingressHostname ))
+    kube:
+     external_ips:
+     - (( shell dig +short $(bx cs cluster-get --cluster ${CLUSTER_NAME} --json | jq --raw-output .ingressHostname) ))
+     storage_class:
+       persistent: "ibmc-file-gold"
+
+- chart_name: cf
+  chart_namespace: cf
+  chart_version: 0
+  chart_location: charts/helm/cf
+  overrides:
+    secrets:
+      CLUSTER_ADMIN_PASSWORD: changeme
+      UAA_ADMIN_CLIENT_SECRET: MyUaaAdminClientSecret
+      UAA_CA_CERT: (( shell kubectl --namespace uaa get pods --output json | jq --raw-output ".items[].spec.containers[] | select(.name == \"uaa\") | .env[] | select(.name == \"INTERNAL_CA_CERT\") | [ .valueFrom.secretKeyRef.name, .valueFrom.secretKeyRef.key ] | @tsv" | while read -r SECRET_NAME SECRET_KEY; do kubectl --namespace uaa get secret "${SECRET_NAME}" --output json | jq --raw-output ".data[\"${SECRET_KEY}\"]" | base64 -d; done ))
+    env:
+      DOMAIN: (( shell bx cs cluster-get --cluster ${CLUSTER_NAME} --json | jq --raw-output .ingressHostname ))
+      TCP_DOMAIN: tcp.(( shell bx cs cluster-get --cluster ${CLUSTER_NAME} --json | jq --raw-output .ingressHostname ))
+      UAA_HOST: uaa.(( shell bx cs cluster-get --cluster ${CLUSTER_NAME} --json | jq --raw-output .ingressHostname ))
+      UAA_PORT: 2793
+      INSECURE_DOCKER_REGISTRIES: "\"insecure-registry.(( shell bx cs cluster-get --cluster ${CLUSTER_NAME} --json | jq --raw-output .ingressHostname )):20005\""
+    kube:
+      external_ips:
+      - 192.0.2.42
+      - (( shell dig +short $(bx cs cluster-get --cluster ${CLUSTER_NAME} --json | jq --raw-output .ingressHostname) ))
+      storage_class:
+        persistent: "ibmc-file-gold"
+
+EOF
+
+havener purge --non-interactive uaa cf
+havener deploy --config armada-deploy.yml
+
+CF_NAMESPACE=cf
+BASE_SECRET="$(kubectl --namespace "${CF_NAMESPACE}" get cm secrets-config --output json | jq --raw-output '.data["current-secrets-name"]')"
+DOMAIN="$(bx cs cluster-get --cluster "${CLUSTER_NAME}" --json | jq --raw-output .ingressHostname)"
+kubectl create secret generic --namespace "${CF_NAMESPACE}" router-secret \
+  --from-file=tls.crt=<(kubectl --namespace "${CF_NAMESPACE}" get secret "${BASE_SECRET}" --output json | jq --raw-output '.data["router-ssl-cert"]' | base64 -d) \
+  --from-file=tls.key=<(kubectl --namespace "${CF_NAMESPACE}" get secret "${BASE_SECRET}" --output json | jq --raw-output '.data["router-ssl-cert-key"]' | base64 -d)
+kubectl --namespace "${CF_NAMESPACE}" apply --wait --filename - <<EOF
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    ingress.bluemix.net/client-max-body-size: 1536m
+  name: router
+  namespace: cf
+spec:
+  rules:
+  - host: '*.${DOMAIN}'
+    http:
+      paths:
+      - backend:
+          serviceName: router-gorouter-public
+          servicePort: 80
+        path: /
+  tls:
+  - hosts:
+    - '*.${DOMAIN}'
+    secretName: router-secret
+EOF

--- a/pipelines/scf-build-deploy/scripts/deploy.sh
+++ b/pipelines/scf-build-deploy/scripts/deploy.sh
@@ -16,7 +16,7 @@ releases:
   chart_location: charts/helm/uaa
   overrides:
     secrets:
-      UAA_ADMIN_CLIENT_SECRET: MyUaaAdminClientSecret
+      UAA_ADMIN_CLIENT_SECRET: foobar
     env:
       DOMAIN: (( shell bx cs cluster-get --cluster ${CLUSTER_NAME} --json | jq --raw-output .ingressHostname ))
     kube:
@@ -32,7 +32,7 @@ releases:
   overrides:
     secrets:
       CLUSTER_ADMIN_PASSWORD: changeme
-      UAA_ADMIN_CLIENT_SECRET: MyUaaAdminClientSecret
+      UAA_ADMIN_CLIENT_SECRET: foobar
       UAA_CA_CERT: (( shell kubectl --namespace uaa get pods --output json | jq --raw-output ".items[].spec.containers[] | select(.name == \"uaa\") | .env[] | select(.name == \"INTERNAL_CA_CERT\") | [ .valueFrom.secretKeyRef.name, .valueFrom.secretKeyRef.key ] | @tsv" | while read -r SECRET_NAME SECRET_KEY; do kubectl --namespace uaa get secret "${SECRET_NAME}" --output json | jq --raw-output ".data[\"${SECRET_KEY}\"]" | base64 -d; done ))
     env:
       DOMAIN: (( shell bx cs cluster-get --cluster ${CLUSTER_NAME} --json | jq --raw-output .ingressHostname ))

--- a/pipelines/scf-build-deploy/scripts/test.sh
+++ b/pipelines/scf-build-deploy/scripts/test.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -euo pipefail
+
+bx login -a "${BX_API}" --apikey "${BX_API_KEY}"
+eval "$(bx cs cluster-config "${CLUSTER_NAME}" --export)"
+
+tar -xzf scf-helm-charts/scf-*-helm.tar.gz
+
+DOMAIN="$(bx cs cluster-get --cluster "${CLUSTER_NAME}" --json | jq --raw-output .ingressHostname)"
+perl -pi -e "s/cf-dev.io/${DOMAIN}/" kube/cf/bosh-task/acceptance-tests.yaml
+
+# TODO Verify how much we can scale the tests
+perl -pi -e 's/value: "4"/value: "2"/' kube/cf/bosh-task/acceptance-tests.yaml
+
+if kubectl --namespace=cf get pod acceptance-tests >/dev/null 2>&1; then
+  kubectl delete \
+    --namespace=cf \
+    --wait \
+    pod/acceptance-tests
+fi
+
+kubectl create \
+  --namespace=cf \
+  --filename="kube/cf/bosh-task/acceptance-tests.yaml"
+
+sleep 10
+
+kubectl logs \
+  --namespace=cf \
+  --follow \
+  acceptance-tests
+
+EXIT_CODE=0
+
+if [[ "$(kubectl --namespace=cf get pod acceptance-tests --output json | jq --raw-output '.status.phase')" == "Failed" ]]; then
+  echo "CATs failed"
+  EXIT_CODE=1
+fi
+
+if kubectl --namespace=cf get pod acceptance-tests >/dev/null 2>&1; then
+  kubectl delete \
+    --namespace=cf \
+    --wait \
+    pod/acceptance-tests
+fi
+
+exit ${EXIT_CODE}

--- a/pipelines/scf-build-deploy/vars.yml
+++ b/pipelines/scf-build-deploy/vars.yml
@@ -1,0 +1,1 @@
+sample: sample


### PR DESCRIPTION
This should showcase the interaction of all infrastructure components during the pipeline flow. This includes:
- S3 bucket to save charts and kube files
- docker hub for storing the docker build images
- IBM Armada cluster to deploy SCF version

The pipeline flow consists of:
- build images and helm charts
- deploy them by using [havener](https://github.com/homeport/havener)
- run :smoking:  and  🐱