### PR TITLE
Add pipeline for building and publishing the operator docker image

### DIFF
--- a/dockerfiles/go-tools/Dockerfile
+++ b/dockerfiles/go-tools/Dockerfile
@@ -1,0 +1,12 @@
+FROM opensuse/leap:15
+
+RUN zypper -n ar https://download.opensuse.org/repositories/devel:/languages:/go/openSUSE_Leap_15.0/ go \
+  && zypper -n --gpg-auto-import-keys ref go
+RUN zypper -n install --no-recommends make go1.11 docker
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:$PATH
+
+RUN go get -u golang.org/x/lint/golint
+RUN go get github.com/onsi/ginkgo/ginkgo
+RUN go get github.com/onsi/gomega/...

--- a/pipelines/cf-operator/pipeline.yml
+++ b/pipelines/cf-operator/pipeline.yml
@@ -1,0 +1,46 @@
+resources:
+- name: src
+  type: git
+  tags: [containerization]
+  source:
+    uri: ((src-repo))
+    branch: master
+
+- name: ci
+  type: git
+  tags: [containerization]
+  source:
+    uri: ((ci-repo))
+    branch: ((ci-branch))
+- name: docker.cf-operator
+  type: docker-image
+  source:
+    repository: ((docker-organization))/cf-operator
+    username: ((dockerhub.username))
+    password: ((dockerhub.password))
+
+jobs:
+- name: build
+  plan:
+  - aggregate:
+    - get: ci
+      trigger: true
+    - get: src
+      trigger: true
+  - task: vet
+    tags: [containerization]
+    file: ci/pipelines/cf-operator/tasks/vet.yml
+  - task: lint
+    tags: [containerization]
+    file: ci/pipelines/cf-operator/tasks/lint.yml
+  - task: test
+    tags: [containerization]
+    file: ci/pipelines/cf-operator/tasks/test.yml
+  - task: build
+    tags: [containerization]
+    file: ci/pipelines/cf-operator/tasks/build.yml
+  - put: docker.cf-operator
+    params:
+      build: docker/
+      dockerfile: docker/build/Dockerfile
+      tag: docker/tag

--- a/pipelines/cf-operator/tasks/build.sh
+++ b/pipelines/cf-operator/tasks/build.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+set -ex
+
+export PATH=$PATH:$PWD/bin
+export GOPATH=$PWD
+
+pushd src/code.cloudfoundry.org/cf-operator
+. bin/include/versioning
+popd
+
+set -ex
+make -C src/code.cloudfoundry.org/cf-operator build
+cp -r src/code.cloudfoundry.org/cf-operator/build docker/
+echo $VERSION_TAG > docker/tag

--- a/pipelines/cf-operator/tasks/build.yml
+++ b/pipelines/cf-operator/tasks/build.yml
@@ -1,0 +1,15 @@
+---
+platform: linux
+image_resource:
+ type: docker-image
+ source:
+   repository: cfcontainerization/go-tools
+   tag: latest
+inputs:
+- name: src
+  path: src/code.cloudfoundry.org/cf-operator
+- name: ci
+outputs:
+- name: docker
+run:
+  path: ci/pipelines/cf-operator/tasks/build.sh

--- a/pipelines/cf-operator/tasks/lint.sh
+++ b/pipelines/cf-operator/tasks/lint.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+set -ex
+
+export PATH=$PATH:$PWD/bin
+export GOPATH=$PWD
+
+make -C src/code.cloudfoundry.org/cf-operator lint

--- a/pipelines/cf-operator/tasks/lint.yml
+++ b/pipelines/cf-operator/tasks/lint.yml
@@ -1,0 +1,13 @@
+---
+platform: linux
+image_resource:
+ type: docker-image
+ source:
+   repository: cfcontainerization/go-tools
+   tag: latest
+inputs:
+- name: src
+  path: src/code.cloudfoundry.org/cf-operator
+- name: ci
+run:
+  path: ci/pipelines/cf-operator/tasks/lint.sh

--- a/pipelines/cf-operator/tasks/test.sh
+++ b/pipelines/cf-operator/tasks/test.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+set -ex
+
+export PATH=$PATH:$PWD/bin
+export GOPATH=$PWD
+
+make -C src/code.cloudfoundry.org/cf-operator test-unit

--- a/pipelines/cf-operator/tasks/test.yml
+++ b/pipelines/cf-operator/tasks/test.yml
@@ -1,0 +1,13 @@
+---
+platform: linux
+image_resource:
+ type: docker-image
+ source:
+   repository: cfcontainerization/go-tools
+   tag: latest
+inputs:
+- name: src
+  path: src/code.cloudfoundry.org/cf-operator
+- name: ci
+run:
+  path: ci/pipelines/cf-operator/tasks/test.sh

--- a/pipelines/cf-operator/tasks/vet.sh
+++ b/pipelines/cf-operator/tasks/vet.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+set -ex
+
+export PATH=$PATH:$PWD/bin
+export GOPATH=$PWD
+
+make -C src/code.cloudfoundry.org/cf-operator vet

--- a/pipelines/cf-operator/tasks/vet.yml
+++ b/pipelines/cf-operator/tasks/vet.yml
@@ -1,0 +1,13 @@
+---
+platform: linux
+image_resource:
+ type: docker-image
+ source:
+   repository: cfcontainerization/go-tools
+   tag: latest
+inputs:
+- name: src
+  path: src/code.cloudfoundry.org/cf-operator
+- name: ci
+run:
+  path: ci/pipelines/cf-operator/tasks/vet.sh

--- a/pipelines/cf-operator/vars.yml
+++ b/pipelines/cf-operator/vars.yml
@@ -1,0 +1,4 @@
+src-repo: https://github.com/cloudfoundry-incubator/cf-operator
+ci-repo: https://github.com/cloudfoundry-incubator/cf-operator-ci
+ci-branch: master
+docker-organization: cfcontainerization

--- a/pipelines/images/pipeline.yml
+++ b/pipelines/images/pipeline.yml
@@ -1,0 +1,24 @@
+resources:
+- name: ci
+  type: git
+  tags: [containerization]
+  source:
+    uri: ((ci-repo))
+    branch: ((ci-branch))
+    paths:
+    - dockerfiles
+- name: docker.go-tools
+  type: docker-image
+  source:
+    repository: ((docker-organization))/go-tools
+    username: ((dockerhub.username))
+    password: ((dockerhub.password))
+jobs:
+- name: go-tools
+  plan:
+  - aggregate:
+    - get: ci
+      trigger: true
+  - put: docker.go-tools
+    params:
+      build: ci/dockerfiles/go-tools

--- a/pipelines/images/vars.yml
+++ b/pipelines/images/vars.yml
@@ -1,0 +1,3 @@
+ci-repo: https://github.com/cloudfoundry-incubator/cf-operator-ci
+ci-branch: master
+docker-organization: cfcontainerization


### PR DESCRIPTION
The docker images are pushed to https://hub.docker.com/r/cfcontainerization/cf-operator/

[#161746292](https://www.pivotaltracker.com/story/show/161746292)