### PR TITLE
Push the operator image to dockerhub before running the tests

### DIFF
--- a/pipelines/cf-operator-check/pipeline.yml
+++ b/pipelines/cf-operator-check/pipeline.yml
@@ -27,6 +27,13 @@ resources:
   source:
     uri: ((ci-repo))
     branch: ((ci-branch))
+- name: docker.cf-operator-ci
+  type: docker-image
+  tags: [containerization]
+  source:
+    repository: ((docker-organization))/cf-operator-ci
+    username: ((dockerhub.username))
+    password: ((dockerhub.password))
 
 jobs:
 - name: vet
@@ -106,6 +113,13 @@ jobs:
       description: go test check
       path: src
       state: pending
+  - task: build
+    tags: [containerization]
+    file: ci/pipelines/cf-operator/tasks/build.yml
+  - put: docker.cf-operator-ci
+    params:
+      build: src
+      tag: docker/tag
   - do:
     - task: test
       tags: [containerization]

--- a/pipelines/cf-operator-check/vars.yml
+++ b/pipelines/cf-operator-check/vars.yml
@@ -1,3 +1,4 @@
 pr-repo: cloudfoundry-incubator/cf-operator
 ci-repo: https://github.com/cloudfoundry-incubator/cf-operator-ci
 ci-branch: master
+docker-organization: cfcontainerization


### PR DESCRIPTION
The image will be required for running the integration tests in the future.