### PR TITLE
Split master tests

### DIFF
--- a/pipelines/cf-operator-nightly/pipeline.yml
+++ b/pipelines/cf-operator-nightly/pipeline.yml
@@ -19,7 +19,6 @@ resources:
 jobs:
 - name: test
   serial: true
-  serial_groups: [go-cache]
   plan:
   - aggregate:
     - get: ci
@@ -46,7 +45,6 @@ jobs:
 
 - name: build
   serial: true
-  serial_groups: [go-cache]
   plan:
   - aggregate:
     - get: ci

--- a/pipelines/cf-operator/pipeline.yml
+++ b/pipelines/cf-operator/pipeline.yml
@@ -52,6 +52,15 @@ jobs:
   - task: test-unit
     tags: [containerization]
     file: ci/pipelines/cf-operator/tasks/test.yml
+
+- name: test-integration
+  serial: true
+  plan:
+  - aggregate:
+    - get: ci
+    - get: src
+      trigger: true
+      passed: [test]
   - task: test-integration
     tags: [containerization]
     params:
@@ -68,7 +77,7 @@ jobs:
   - aggregate:
     - get: ci
     - get: src
-      passed: [test]
+      passed: [test-integration]
       trigger: true
   - task: build
     tags: [containerization]

--- a/pipelines/cf-operator/pipeline.yml
+++ b/pipelines/cf-operator/pipeline.yml
@@ -38,7 +38,6 @@ resources:
 jobs:
 - name: test
   serial: true
-  serial_groups: [go-cache]
   plan:
   - aggregate:
     - get: ci
@@ -65,7 +64,6 @@ jobs:
 
 - name: build
   serial: true
-  serial_groups: [go-cache]
   plan:
   - aggregate:
     - get: ci


### PR DESCRIPTION
We have to repeat the integration step quite often, so split the `test` job into `test` and `integration`.