### PR TITLE
No longer use cf-operator-check repo from dockerhub

### DIFF
--- a/pipelines/cf-operator-check/pipeline.yml
+++ b/pipelines/cf-operator-check/pipeline.yml
@@ -32,13 +32,6 @@ resources:
   type: docker-image
   tags: [containerization]
   source:
-    repository: ((docker-organization))/cf-operator-ci
-    username: ((dockerhub.username))
-    password: ((dockerhub.password))
-- name: docker.cf-operator
-  type: docker-image
-  tags: [containerization]
-  source:
     repository: ((docker-organization))/((docker-repo))
     username: ((dockerhub.username))
     password: ((dockerhub.password))
@@ -178,7 +171,7 @@ jobs:
     - task: build
       tags: [containerization]
       file: ci/pipelines/cf-operator/tasks/build.yml
-    - put: docker.cf-operator
+    - put: docker.cf-operator-ci
       params:
         build: src
         tag: docker/tag

--- a/pipelines/cf-operator-check/vars.yml
+++ b/pipelines/cf-operator-check/vars.yml
@@ -2,5 +2,5 @@ pr-repo: cloudfoundry-incubator/cf-operator
 ci-repo: https://github.com/cloudfoundry-incubator/cf-operator-ci
 ci-branch: master
 docker-organization: cfcontainerization
-docker-repo: cf-operator-check
+docker-repo: cf-operator-ci
 storageclass: hostpath-containerization

--- a/pipelines/cf-operator/pipeline.yml
+++ b/pipelines/cf-operator/pipeline.yml
@@ -186,6 +186,7 @@ jobs:
       params:
         load: docker.cf-operator-rc
         tag: docker/tag
+        tag_as_latest: true
 
 - name: build-helm
   plan:


### PR DESCRIPTION
Our master pipeline pushes candidates to [cf-operator-candidate](https://hub.docker.com/r/cfcontainerization/cf-operator-candidate) and tags them with 'latest'. After tests they are published to [cf-operator](https://hub.docker.com/r/cfcontainerization/cf-operator).

The check pipeline uses two different folders for docker images. As far as I know, nobody uses those images.

* add the `latest` label to `cf-operator`, when master publishes
* PR pipeline's `build` job now uses the cf-operator-ci, instead of cf-operator-check 