### PR TITLE
Add acl puts flag

### DIFF
--- a/pipelines/cf-operator/pipeline.yml
+++ b/pipelines/cf-operator/pipeline.yml
@@ -202,3 +202,4 @@ jobs:
   - put: s3.helm-charts
     params:
       file: helm-charts/cf-operator-*.zip
+      acl: public-read


### PR DESCRIPTION
- Add a canned ACL of the type, public-read.
  This will allow the AllUsers group(anyone in the world) to
  access the resource.