### PR TITLE
Publish cannot use docker resource

### DIFF
--- a/pipelines/cf-operator/pipeline.yml
+++ b/pipelines/cf-operator/pipeline.yml
@@ -11,13 +11,6 @@ resources:
   source:
     uri: ((ci-repo))
     branch: ((ci-branch))
-- name: docker.cf-operator
-  type: docker-image
-  tags: [containerization]
-  source:
-    repository: ((docker-organization))/cf-operator
-    username: ((dockerhub.username))
-    password: ((dockerhub.password))
 - name: docker.cf-operator-rc
   type: docker-image
   tags: [containerization]
@@ -180,19 +173,19 @@ jobs:
   - task: build
     tags: [containerization]
     file: ci/pipelines/tasks/build.yml
-  - do:
-    - put: s3.cf-operator
-      tags: [containerization]
-      params:
-        file: binaries/cf-operator-*
-    - get: docker.cf-operator-rc
-      params:
-        save: true
-        tag: docker/tag
-    - put: docker.cf-operator
-      params:
-        load: docker.cf-operator-rc
-        tag: docker/tag
+  - task: publish
+    tags: [containerization]
+    privileged: true
+    file: ci/pipelines/cf-operator/tasks/publish.yml
+    params:
+      repository: ((docker-organization))/cf-operator
+      candidate_repository: ((docker-organization))/((docker-candidate-repo))
+      username: ((dockerhub.username))
+      password: ((dockerhub.password))
+  - put: s3.cf-operator
+    tags: [containerization]
+    params:
+      file: binaries/cf-operator-*
 
 - name: build-helm
   plan:

--- a/pipelines/cf-operator/tasks/publish.sh
+++ b/pipelines/cf-operator/tasks/publish.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -ex
+
+# Start Docker Daemon (and set a trap to stop it once this script is done)
+echo 'DOCKER_OPTS="--data-root /scratch/docker --max-concurrent-downloads 10"' >/etc/default/docker
+service docker start
+service docker status
+trap 'service docker stop' EXIT
+sleep 10
+
+echo "$password" | docker login --username "$username" --password-stdin
+
+# Determine version
+VERSION_TAG=$(cat docker/tag)
+
+echo "building for $VERSION_TAG"
+
+CANDIDATE="$candidate_repository:$VERSION_TAG"
+RELEASE="$repository:$VERSION_TAG"
+docker pull "$CANDIDATE"
+docker tag "$CANDIDATE" "$RELEASE"
+docker push "$RELEASE"

--- a/pipelines/cf-operator/tasks/publish.yml
+++ b/pipelines/cf-operator/tasks/publish.yml
@@ -1,0 +1,17 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: havener/build-environment
+    tag: latest
+inputs:
+- name: ci
+- name: docker
+params:
+  repository:
+  candidate_repository:
+  username:
+  password:
+run:
+  path: ci/pipelines/cf-operator/tasks/publish.sh


### PR DESCRIPTION
The Concourse docker resource cannot get a specific version.
Instead we promote our rc image manually to the release repository.