### PR TITLE
Split e2e tests in two parallel running tasks:

### DIFF
--- a/pipelines/cf-operator-check/pipeline.yml
+++ b/pipelines/cf-operator-check/pipeline.yml
@@ -134,19 +134,31 @@ jobs:
     - task: test
       tags: [containerization]
       file: ci/pipelines/tasks/test.yml
-    - task: test-integration
-      tags: [containerization]
-      params:
-        ibmcloud_apikey: ((ibmcloud.key-value))
-        ibmcloud_server: ((ibmcloud.server))
-        ibmcloud_region: ((ibmcloud.region))
-        ibmcloud_cluster: ((ibmcloud.cluster))
-        ssh_server_ip: ((ssh-server.ip))
-        ssh_server_user: ((ssh-server.user))
-        ssh_server_key: ((ssh-server.key))
-        OPERATOR_TEST_STORAGE_CLASS: ((storageclass))
-        DOCKER_IMAGE_REPOSITORY: ((docker-repo))
-      file: ci/pipelines/tasks/test-integration.yml
+    - aggregate:
+      - task: test-integration
+        tags: [containerization]
+        params:
+          ibmcloud_apikey: ((ibmcloud.key-value))
+          ibmcloud_server: ((ibmcloud.server))
+          ibmcloud_region: ((ibmcloud.region))
+          ibmcloud_cluster: ((ibmcloud.cluster))
+          ssh_server_ip: ((ssh-server.ip))
+          ssh_server_user: ((ssh-server.user))
+          ssh_server_key: ((ssh-server.key))
+          OPERATOR_TEST_STORAGE_CLASS: ((storageclass))
+          DOCKER_IMAGE_REPOSITORY: ((docker-repo))
+        file: ci/pipelines/tasks/test-integration.yml
+      - task: test-helm-e2e
+        tags: [containerization]
+        params:
+          ibmcloud_apikey: ((ibmcloud.key-value))
+          ibmcloud_server: ((ibmcloud.server))
+          ibmcloud_region: ((ibmcloud.region))
+          ibmcloud_cluster: ((ibmcloud.cluster-dino))
+          ssh_server_ip: ((ssh-server.ip))
+          ssh_server_user: ((ssh-server.user))
+          ssh_server_key: ((ssh-server.key))
+        file: ci/pipelines/tasks/test-helm-e2e.yml
     on_failure:
       put: status
       tags: [containerization]

--- a/pipelines/cf-operator-nightly/pipeline.yml
+++ b/pipelines/cf-operator-nightly/pipeline.yml
@@ -43,19 +43,31 @@ jobs:
   - task: test-unit
     tags: [containerization]
     file: ci/pipelines/tasks/test.yml
-  - task: test-integration
-    tags: [containerization]
-    params:
-      ibmcloud_apikey: ((ibmcloud.key-value))
-      ibmcloud_server: ((ibmcloud.server))
-      ibmcloud_region: ((ibmcloud.region))
-      ibmcloud_cluster: ((ibmcloud.cluster))
-      ssh_server_ip: ((ssh-server.ip))
-      ssh_server_user: ((ssh-server.user))
-      ssh_server_key: ((ssh-server.key))
-      OPERATOR_TEST_STORAGE_CLASS: ((storageclass))
-      DOCKER_IMAGE_REPOSITORY: ((docker-candidate-repo))
-    file: ci/pipelines/tasks/test-integration.yml
+  - aggregate:
+    - task: test-integration
+      tags: [containerization]
+      params:
+        ibmcloud_apikey: ((ibmcloud.key-value))
+        ibmcloud_server: ((ibmcloud.server))
+        ibmcloud_region: ((ibmcloud.region))
+        ibmcloud_cluster: ((ibmcloud.cluster))
+        ssh_server_ip: ((ssh-server.ip))
+        ssh_server_user: ((ssh-server.user))
+        ssh_server_key: ((ssh-server.key))
+        OPERATOR_TEST_STORAGE_CLASS: ((storageclass))
+        DOCKER_IMAGE_REPOSITORY: ((docker-candidate-repo))
+      file: ci/pipelines/tasks/test-integration.yml
+    - task: test-helm-e2e
+      tags: [containerization]
+      params:
+        ibmcloud_apikey: ((ibmcloud.key-value))
+        ibmcloud_server: ((ibmcloud.server))
+        ibmcloud_region: ((ibmcloud.region))
+        ibmcloud_cluster: ((ibmcloud.cluster-dino))
+        ssh_server_ip: ((ssh-server.ip))
+        ssh_server_user: ((ssh-server.user))
+        ssh_server_key: ((ssh-server.key))
+      file: ci/pipelines/tasks/test-helm-e2e.yml
 
 - name: build
   serial: true

--- a/pipelines/cf-operator/pipeline.yml
+++ b/pipelines/cf-operator/pipeline.yml
@@ -123,20 +123,32 @@ jobs:
       passed: [build]
     - get: s3.code-coverage-unit
       passed: [build]
-  - task: test-integration
-    tags: [containerization]
-    params:
-      ibmcloud_apikey: ((ibmcloud.key-value))
-      ibmcloud_server: ((ibmcloud.server))
-      ibmcloud_region: ((ibmcloud.region))
-      ibmcloud_cluster: ((ibmcloud.cluster))
-      ssh_server_ip: ((ssh-server.ip))
-      ssh_server_user: ((ssh-server.user))
-      ssh_server_key: ((ssh-server.key))
-      OPERATOR_TEST_STORAGE_CLASS: ((storageclass))
-      DOCKER_IMAGE_REPOSITORY: ((docker-candidate-repo))
-      COVERAGE: true
-    file: ci/pipelines/tasks/test-integration.yml
+  - aggregate:
+    - task: test-integration
+      tags: [containerization]
+      params:
+        ibmcloud_apikey: ((ibmcloud.key-value))
+        ibmcloud_server: ((ibmcloud.server))
+        ibmcloud_region: ((ibmcloud.region))
+        ibmcloud_cluster: ((ibmcloud.cluster))
+        ssh_server_ip: ((ssh-server.ip))
+        ssh_server_user: ((ssh-server.user))
+        ssh_server_key: ((ssh-server.key))
+        OPERATOR_TEST_STORAGE_CLASS: ((storageclass))
+        DOCKER_IMAGE_REPOSITORY: ((docker-candidate-repo))
+        COVERAGE: true
+      file: ci/pipelines/tasks/test-integration.yml
+    - task: test-helm-e2e
+      tags: [containerization]
+      params:
+        ibmcloud_apikey: ((ibmcloud.key-value))
+        ibmcloud_server: ((ibmcloud.server))
+        ibmcloud_region: ((ibmcloud.region))
+        ibmcloud_cluster: ((ibmcloud.cluster-dino))
+        ssh_server_ip: ((ssh-server.ip))
+        ssh_server_user: ((ssh-server.user))
+        ssh_server_key: ((ssh-server.key))
+      file: ci/pipelines/tasks/test-helm-e2e.yml
   - put: s3.code-coverage-integration
     tags: [containerization]
     params:

--- a/pipelines/tasks/test-helm-e2e.sh
+++ b/pipelines/tasks/test-helm-e2e.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env sh
+set -eu
+
+export PATH=$PATH:$PWD/bin
+export GOPATH=$PWD
+export GO111MODULE=on
+export TEST_NAMESPACE="default"
+
+
+# Random port to support parallelism with different webhook servers
+export CF_OPERATOR_WEBHOOK_SERVICE_PORT=$(( ( RANDOM % 62000 )  + 2000 ))
+export TUNNEL_NAME="tunnelpod-${CF_OPERATOR_WEBHOOK_SERVICE_PORT}"
+
+## Make sure to cleanup the tunnel pod and service
+cleanup () {
+  echo "Cleaning up"
+  pidof ssh | xargs kill
+}
+trap cleanup EXIT
+
+echo "Seting up bluemix access"
+ibmcloud login -a "$ibmcloud_server" --apikey "$ibmcloud_apikey"
+ibmcloud cs  region-set "$ibmcloud_region"
+eval $(ibmcloud cs cluster-config "$ibmcloud_cluster" --export)
+
+echo "Seting up SSH tunnel for webhook"
+cat <<EOF > identity
+$ssh_server_key
+EOF
+chmod 0600 identity
+
+# GatewayPorts option needs to be enabled on ssh server
+ssh -fNT -i identity -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -R "${ssh_server_ip}:${CF_OPERATOR_WEBHOOK_SERVICE_PORT}:localhost:${CF_OPERATOR_WEBHOOK_SERVICE_PORT}" "${ssh_server_user}@${ssh_server_ip}"
+
+echo "Seting up webhook on k8s"
+cat <<EOF | kubectl create -f - --namespace=${TEST_NAMESPACE}
+---
+kind: Endpoints
+apiVersion: v1
+metadata:
+  name: ${TUNNEL_NAME}
+subsets:
+  - addresses:
+      - ip: ${ssh_server_ip}
+    ports:
+      - port: ${CF_OPERATOR_WEBHOOK_SERVICE_PORT}
+EOF
+export CF_OPERATOR_WEBHOOK_SERVICE_HOST="$ssh_server_ip"
+
+
+echo "Running e2e tests with helm"
+# fix SSL path
+kube_path=$(dirname "$KUBECONFIG")
+sed -i 's@certificate-authority: \(.*\)$@certificate-authority: '$kube_path'/\1@' $KUBECONFIG
+make -C src/code.cloudfoundry.org/cf-operator test-helm-e2e

--- a/pipelines/tasks/test-helm-e2e.yml
+++ b/pipelines/tasks/test-helm-e2e.yml
@@ -1,0 +1,15 @@
+---
+platform: linux
+image_resource:
+ type: docker-image
+ source:
+   repository: cfcontainerization/go-tools
+   tag: latest
+inputs:
+- name: src
+  path: src/code.cloudfoundry.org/cf-operator
+- name: ci
+caches:
+- path: pkg/mod # Persist go modules cache
+run:
+  path: ci/pipelines/tasks/test-helm-e2e.sh


### PR DESCRIPTION
- keep integration task the same
- add a new task in the integration job, to run e2e tests with helm
- add 2 new files, that define the e2e with helm task.

This change applies to the following pipelines:
- cf-operator
- cf-operator-check
- cf-operator-nightly

The new task is using a new cluster, to only run the helm install.