### PR TITLE
Remove e2e kube tests from check pipeline

### DIFF
--- a/pipelines/cf-operator-check/pipeline.yml
+++ b/pipelines/cf-operator-check/pipeline.yml
@@ -148,18 +148,6 @@ jobs:
           OPERATOR_TEST_STORAGE_CLASS: ((storageclass))
           DOCKER_IMAGE_REPOSITORY: ((docker-repo))
         file: ci/pipelines/tasks/test-integration.yml
-      - task: test-helm-e2e
-        tags: [containerization]
-        params:
-          ibmcloud_apikey: ((ibmcloud.key-value))
-          ibmcloud_server: ((ibmcloud.server))
-          ibmcloud_region: ((ibmcloud.region))
-          ibmcloud_cluster: ((ibmcloud.cluster-dino))
-          ssh_server_ip: ((ssh-server.ip))
-          ssh_server_user: ((ssh-server.user))
-          ssh_server_key: ((ssh-server.key))
-          DOCKER_IMAGE_REPOSITORY: ((docker-repo))
-        file: ci/pipelines/tasks/test-helm-e2e.yml
     on_failure:
       put: status
       tags: [containerization]


### PR DESCRIPTION
We're only going to run them on master and nightly.

[#166115702](https://www.pivotaltracker.com/story/show/166115702)