### PR TITLE
166206612 vendor submodule

### DIFF
--- a/pipelines/cf-operator-check/pipeline.yml
+++ b/pipelines/cf-operator-check/pipeline.yml
@@ -10,7 +10,7 @@ resource_types:
     tag: release
 
 resources:
-- name: src
+- name: pr-src
   type: pull-request
   tags: [containerization]
   webhook_token: ((github.webhook-token))
@@ -52,14 +52,17 @@ jobs:
   plan:
   - aggregate:
     - get: ci
-    - get: src
+    - get: pr-src
       trigger: true
+  - task: vendorize-src
+    tags: [containerization]
+    file: ci/pipelines/cf-operator-check/tasks/vendor-src.yml
   - put: status
     tags: [containerization]
     params:
       context: vet
       description: go vet check
-      path: src
+      path: pr-src
       state: pending
   - do:
     - task: vet
@@ -71,7 +74,7 @@ jobs:
       params:
         context: vet
         description: go vet check
-        path: src
+        path: pr-src
         state: failure
     on_success:
       put: status
@@ -79,7 +82,7 @@ jobs:
       params:
         context: vet
         description: go vet check
-        path: src
+        path: pr-src
         state: success
 
 - name: lint
@@ -87,14 +90,14 @@ jobs:
   plan:
   - aggregate:
     - get: ci
-    - get: src
+    - get: pr-src
       trigger: true
   - put: status
     tags: [containerization]
     params:
       context: lint
       description: lint check
-      path: src
+      path: pr-src
       state: pending
   - do:
     - task: lint
@@ -106,7 +109,7 @@ jobs:
       params:
         context: lint
         description: go lint check
-        path: src
+        path: pr-src
         state: failure
     on_success:
       put: status
@@ -114,7 +117,7 @@ jobs:
       params:
         context: lint
         description: go lint check
-        path: src
+        path: pr-src
         state: success
 
 - name: test
@@ -122,14 +125,17 @@ jobs:
   plan:
   - aggregate:
     - get: ci
-    - get: src
+    - get: pr-src
       trigger: true
+  - task: vendorize-src
+    tags: [containerization]
+    file: ci/pipelines/cf-operator-check/tasks/vendorize-src.yml
   - put: status
     tags: [containerization]
     params:
       context: test
       description: go test check
-      path: src
+      path: pr-src
       state: pending
   - task: build
     tags: [containerization]
@@ -171,7 +177,7 @@ jobs:
         params:
           context: test
           description: go test check
-          path: src
+          path: pr-src
           state: failure
     on_success:
       put: status
@@ -179,7 +185,7 @@ jobs:
       params:
         context: test
         decription: go test check
-        path: src
+        path: pr-src
         state: success
 
 - name: build
@@ -187,14 +193,17 @@ jobs:
   plan:
   - aggregate:
     - get: ci
-    - get: src
+    - get: pr-src
       trigger: true
+  - task: vendorize-src
+    tags: [containerization]
+    file: ci/pipelines/cf-operator-check/tasks/vendorize-src.yml
   - put: status
     tags: [containerization]
     params:
       context: build
       description: go build check
-      path: src
+      path: pr-src
       state: pending
   - do:
     - task: build
@@ -212,7 +221,7 @@ jobs:
       params:
         context: build
         description: go build check
-        path: src
+        path: pr-src
         state: failure
     on_success:
       put: status
@@ -220,5 +229,5 @@ jobs:
       params:
         context: build
         decription: go build check
-        path: src
+        path: pr-src
         state: success

--- a/pipelines/cf-operator-check/pipeline.yml
+++ b/pipelines/cf-operator-check/pipeline.yml
@@ -130,22 +130,50 @@ jobs:
   - task: vendorize-src
     tags: [containerization]
     file: ci/pipelines/cf-operator-check/tasks/vendorize-src.yml
-  - put: status
-    tags: [containerization]
-    params:
-      context: test
-      description: go test check
-      path: pr-src
-      state: pending
-  - task: build
-    tags: [containerization]
-    file: ci/pipelines/tasks/build.yml
-  - put: docker.cf-operator-ci
-    params:
-      build: src
-      build_args:
-        GO111MODULE: 'off'
-      tag: docker/tag
+
+  - aggregate:
+    - put: status
+      tags: [containerization]
+      params:
+        context: build
+        description: go build check
+        path: pr-src
+        state: pending
+    - put: status
+      tags: [containerization]
+      params:
+        context: test
+        description: go test check
+        path: pr-src
+        state: pending
+
+  - do:
+    - task: build
+      tags: [containerization]
+      file: ci/pipelines/tasks/build.yml
+    - put: docker.cf-operator-ci
+      params:
+        build: src
+        build_args:
+          GO111MODULE: 'off'
+        tag: docker/tag
+    on_failure:
+      put: status
+      tags: [containerization]
+      params:
+        context: build
+        description: go build check
+        path: pr-src
+        state: failure
+    on_success:
+      put: status
+      tags: [containerization]
+      params:
+        context: build
+        decription: go build check
+        path: pr-src
+        state: success
+
   - do:
     - task: test
       tags: [containerization]
@@ -185,49 +213,5 @@ jobs:
       params:
         context: test
         decription: go test check
-        path: pr-src
-        state: success
-
-- name: build
-  serial: true
-  plan:
-  - aggregate:
-    - get: ci
-    - get: pr-src
-      trigger: true
-  - task: vendorize-src
-    tags: [containerization]
-    file: ci/pipelines/cf-operator-check/tasks/vendorize-src.yml
-  - put: status
-    tags: [containerization]
-    params:
-      context: build
-      description: go build check
-      path: pr-src
-      state: pending
-  - do:
-    - task: build
-      tags: [containerization]
-      file: ci/pipelines/tasks/build.yml
-    - put: docker.cf-operator-ci
-      params:
-        build: src
-        build_args:
-          GO111MODULE: 'off'
-        tag: docker/tag
-    on_failure:
-      put: status
-      tags: [containerization]
-      params:
-        context: build
-        description: go build check
-        path: pr-src
-        state: failure
-    on_success:
-      put: status
-      tags: [containerization]
-      params:
-        context: build
-        decription: go build check
         path: pr-src
         state: success

--- a/pipelines/cf-operator-check/pipeline.yml
+++ b/pipelines/cf-operator-check/pipeline.yml
@@ -137,6 +137,8 @@ jobs:
   - put: docker.cf-operator-ci
     params:
       build: src
+      build_args:
+        GO111MODULE: 'off'
       tag: docker/tag
   - do:
     - task: test
@@ -201,6 +203,8 @@ jobs:
     - put: docker.cf-operator-ci
       params:
         build: src
+        build_args:
+          GO111MODULE: 'off'
         tag: docker/tag
     on_failure:
       put: status

--- a/pipelines/cf-operator-check/tasks/vendorize-src.sh
+++ b/pipelines/cf-operator-check/tasks/vendorize-src.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+set -ex
+
+cp -a pr-src/. src/
+cd src
+git submodule update --init

--- a/pipelines/cf-operator-check/tasks/vendorize-src.yml
+++ b/pipelines/cf-operator-check/tasks/vendorize-src.yml
@@ -1,0 +1,14 @@
+---
+platform: linux
+image_resource:
+ type: docker-image
+ source:
+   repository: cfcontainerization/go-tools
+   tag: latest
+inputs:
+- name: ci
+- name: pr-src
+outputs:
+- name: src
+run:
+  path: ci/pipelines/cf-operator-check/tasks/vendorize-src.sh

--- a/pipelines/cf-operator-nightly/pipeline.yml
+++ b/pipelines/cf-operator-nightly/pipeline.yml
@@ -84,6 +84,8 @@ jobs:
   - put: docker.cf-operator-rc
     params:
       build: src
+      build_args:
+        GO111MODULE: 'off'
       tag: docker/tag
 
 - name: build-helm

--- a/pipelines/cf-operator/pipeline.yml
+++ b/pipelines/cf-operator/pipeline.yml
@@ -118,6 +118,8 @@ jobs:
     - put: docker.cf-operator-rc
       params:
         build: src
+        build_args:
+          GO111MODULE: 'off'
         tag: docker/tag
 
 - name: test-integration

--- a/pipelines/cf-operator/tasks/coverage.sh
+++ b/pipelines/cf-operator/tasks/coverage.sh
@@ -3,7 +3,6 @@ set -ex
 
 export PATH=$PATH:$PWD/bin
 export GOPATH=$PWD
-export GO111MODULE=on
 
 version=
 

--- a/pipelines/tasks/build-helm.sh
+++ b/pipelines/tasks/build-helm.sh
@@ -3,7 +3,6 @@ set -ex
 
 export PATH=$PATH:$PWD/bin
 export GOPATH=$PWD
-export GO111MODULE=on
 
 pushd src/code.cloudfoundry.org/cf-operator
 . bin/include/versioning

--- a/pipelines/tasks/build.sh
+++ b/pipelines/tasks/build.sh
@@ -3,7 +3,6 @@ set -ex
 
 export PATH=$PATH:$PWD/bin
 export GOPATH=$PWD
-export GO111MODULE=on
 
 pushd src/code.cloudfoundry.org/cf-operator
 git describe --tags --long || git tag v0.0.0 # Make sure there's always a tag that can be used for building the version

--- a/pipelines/tasks/lint.sh
+++ b/pipelines/tasks/lint.sh
@@ -3,6 +3,5 @@ set -ex
 
 export PATH=$PATH:$PWD/bin
 export GOPATH=$PWD
-export GO111MODULE=on
 
 make -C src/code.cloudfoundry.org/cf-operator lint

--- a/pipelines/tasks/test-helm-e2e.sh
+++ b/pipelines/tasks/test-helm-e2e.sh
@@ -3,7 +3,6 @@ set -eu
 
 export PATH=$PATH:$PWD/bin
 export GOPATH=$PWD
-export GO111MODULE=on
 export TEST_NAMESPACE="test$(date +%s)"
 
 # Random port to support parallelism with different webhook servers

--- a/pipelines/tasks/test-integration.sh
+++ b/pipelines/tasks/test-integration.sh
@@ -13,7 +13,6 @@ set -eu
 
 export PATH=$PATH:$PWD/bin
 export GOPATH=$PWD
-export GO111MODULE=on
 export TEST_NAMESPACE="test$(date +%s)"
 
 ## File used for coverage reporting

--- a/pipelines/tasks/test.sh
+++ b/pipelines/tasks/test.sh
@@ -3,7 +3,6 @@ set -ex
 
 export PATH=$PATH:$PWD/bin
 export GOPATH=$PWD
-export GO111MODULE=on
 
 version=
 

--- a/pipelines/tasks/vet.sh
+++ b/pipelines/tasks/vet.sh
@@ -3,6 +3,5 @@ set -ex
 
 export PATH=$PATH:$PWD/bin
 export GOPATH=$PWD
-export GO111MODULE=on
 
 make -C src/code.cloudfoundry.org/cf-operator vet


### PR DESCRIPTION
This depends on https://github.com/cloudfoundry-incubator/cf-operator/pull/275 being in master.

CI was changed to use the Git submodule.

Since the Concourse Github PR resource doesn't support submodules, an extra task was added in the check pipeline.
The other pipelines should clone the submodule by default, according to the Git resource docs: https://github.com/concourse/git-resource#in-clone-the-repository-at-the-given-ref

* lint doesn't require the vendor folder
* we did `build` twice, by putting the github status inside the test job we should be able to build only once

[#166206612](https://www.pivotaltracker.com/story/show/166206612)