### PR TITLE
Created release-images-cf-deployment pipeline

### DIFF
--- a/dockerfiles/base-ci/Dockerfile
+++ b/dockerfiles/base-ci/Dockerfile
@@ -3,11 +3,19 @@ FROM opensuse/leap:15.1
 RUN zypper --non-interactive addrepo https://download.opensuse.org/repositories/Virtualization:containers/openSUSE_Leap_15.1/Virtualization:containers.repo
 RUN zypper --gpg-auto-import-keys refresh
 RUN zypper --non-interactive install \
+  bind-utils \
   curl \
   docker \
+  gcc \
+  git \
   gzip \
   jq \
+  make \
   python \
-  python2-pip
+  python2-pip \
+  ruby \
+  unzip \
+  vim \
+  zip
 RUN pip install --upgrade pip
 RUN pip install yq

--- a/dockerfiles/go-tools/Dockerfile
+++ b/dockerfiles/go-tools/Dockerfile
@@ -1,6 +1,4 @@
-FROM opensuse/leap:15
-
-RUN zypper -n install --no-recommends make git docker zip curl gzip gcc ruby vim jq unzip bind-utils
+FROM cfcontainerization/base-ci:latest
 
 ADD https://github.com/SUSE/kctl/releases/download/v0.0.12/kctl-linux-amd64 /usr/bin/k
 RUN chmod +x /usr/bin/k

--- a/pipelines/release-images-cf-deployment/Dockerfile
+++ b/pipelines/release-images-cf-deployment/Dockerfile
@@ -1,0 +1,13 @@
+FROM opensuse/leap:15.1
+
+RUN zypper --non-interactive addrepo https://download.opensuse.org/repositories/Virtualization:containers/openSUSE_Leap_15.1/Virtualization:containers.repo
+RUN zypper --gpg-auto-import-keys refresh
+RUN zypper --non-interactive install \
+  curl \
+  docker \
+  gzip \
+  jq \
+  python \
+  python2-pip
+RUN pip install --upgrade pip
+RUN pip install yq

--- a/pipelines/release-images-cf-deployment/pipeline.yml
+++ b/pipelines/release-images-cf-deployment/pipeline.yml
@@ -1,0 +1,72 @@
+# This pipeline will setup the build for all the cf_deployment_releases specified below.
+
+<%
+cf_deployment_tags = %w(v7.11.0 v8.0.0 v8.1.0 v9.0.0 v9.2.0)
+%>
+
+resources:
+- name: ci
+  type: git
+  tags: [containerization]
+  source:
+    uri: ((ci-repo))
+    branch: ((ci-branch))
+- name: docker-image-resource
+  type: git
+  tags: [containerization]
+  source:
+    uri: ((docker-image-resource-repo))
+    branch: ((docker-image-resource-branch))
+<% cf_deployment_tags.each do |cf_deployment_tag| %>
+- name: cf-deployment-<%= cf_deployment_tag %>
+  type: git
+  tags: [containerization]
+  source:
+    uri: ((cf-deployment-repo))
+    branch: ((cf-deployment-branch))
+    tag_filter: <%= cf_deployment_tag %>
+<% end %>
+- name: s3.fissile-linux
+  type: s3
+  tags: [containerization]
+  source:
+    bucket: ((s3-bucket))
+    private: true
+    regexp: fissile/develop/fissile-(.*)\.tgz
+- name: s3.fissile-stemcell-opensuse-version
+  type: s3
+  tags: [containerization]
+  source:
+    bucket: ((versions-s3-bucket))
+    access_key_id: ((s3.accessKey))
+    secret_access_key: ((s3.secretKey))
+    versioned_file: fissile-stemcell-versions/fissile-stemcell-opensuse-version
+
+jobs:
+<% cf_deployment_tags.each do |cf_deployment_tag| %>
+- name: build-<%= cf_deployment_tag %>
+  plan:
+  - aggregate:
+    - get: ci
+    - get: docker-image-resource
+    - get: cf-deployment-<%= cf_deployment_tag %>
+    - get: s3.fissile-stemcell-opensuse-version
+      trigger: true
+    - get: s3.fissile-linux
+      trigger: true
+  - do:
+    - task: build
+      privileged: true
+      input_mapping:
+        s3.stemcell-version: s3.fissile-stemcell-opensuse-version
+        cf-deployment: cf-deployment-<%= cf_deployment_tag %>
+      tags: [containerization]
+      params:
+        STEMCELL_OS: ((stemcell-os))
+        STEMCELL_REPOSITORY: ((stemcell-repository))
+        CF_DEPLOYMENT_YAML: ((cf-deployment-yaml))
+        DOCKER_ORGANIZATION: ((docker-organization))
+        DOCKER_TEAM_USERNAME: ((dockerhub.username))
+        DOCKER_TEAM_PASSWORD_RW: ((dockerhub.password))
+      file: ci/pipelines/release-images-cf-deployment/tasks/build.yml
+<% end %>

--- a/pipelines/release-images-cf-deployment/tasks/build.sh
+++ b/pipelines/release-images-cf-deployment/tasks/build.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset
+
+# Start the Docker daemon.
+source docker-image-resource/assets/common.sh
+max_concurrent_downloads=10
+max_concurrent_uploads=10
+insecure_registries=""
+registry_mirror=""
+start_docker \
+  "${max_concurrent_downloads}" \
+  "${max_concurrent_uploads}" \
+  "${insecure_registries}" \
+  "${registry_mirror}"
+trap 'stop_docker' EXIT
+
+# Login to the Docker registry.
+echo "${DOCKER_TEAM_PASSWORD_RW}" | docker login --username "${DOCKER_TEAM_USERNAME}" --password-stdin
+
+# Extract the fissile binary.
+tar xvf s3.fissile-linux/fissile-*.tgz --directory "/usr/local/bin/"
+
+# Pull the stemcell image.
+stemcell_version="$(cat s3.stemcell-version/*-version)"
+stemcell_image="${STEMCELL_REPOSITORY}:${stemcell_version}"
+docker pull "${stemcell_image}"
+
+# Build the releases.
+tasks_dir="$(dirname $0)"
+bash <(yq -r ".manifest_version as \$cf_version | .releases[] | \"source ${tasks_dir}/build_release.sh; build_release \\(\$cf_version|@sh) '${DOCKER_ORGANIZATION}' '${STEMCELL_OS}' '${stemcell_version}' '${stemcell_image}' \\(.name|@sh) \\(.url|@sh) \\(.version|@sh) \\(.sha1|@sh)\"" "${CF_DEPLOYMENT_YAML}")

--- a/pipelines/release-images-cf-deployment/tasks/build.yml
+++ b/pipelines/release-images-cf-deployment/tasks/build.yml
@@ -1,0 +1,22 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: thulioassis/fissile-cf-deployment-ci
+    tag: latest
+inputs:
+- name: ci
+- name: docker-image-resource
+- name: cf-deployment
+- name: s3.stemcell-version
+- name: s3.fissile-linux
+params:
+  STEMCELL_OS:
+  STEMCELL_REPOSITORY:
+  CF_DEPLOYMENT_YAML:
+  DOCKER_ORGANIZATION:
+  DOCKER_TEAM_USERNAME:
+  DOCKER_TEAM_PASSWORD_RW:
+run:
+  path: ci/pipelines/release-images-cf-deployment/tasks/build.sh

--- a/pipelines/release-images-cf-deployment/tasks/build.yml
+++ b/pipelines/release-images-cf-deployment/tasks/build.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: thulioassis/fissile-cf-deployment-ci
+    repository: cfcontainerization/base-ci 
     tag: latest
 inputs:
 - name: ci

--- a/pipelines/release-images-cf-deployment/tasks/build_release.sh
+++ b/pipelines/release-images-cf-deployment/tasks/build_release.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset
+
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+function build_release() {
+  cf_version="${1}"
+  docker_organization="${2}"
+  stemcell_os="${3}"
+  stemcell_version="${4}"
+  stemcell_image="${5}"
+  release_name="${6}"
+  release_url="${7}"
+  release_version="${8}"
+  release_sha1="${9}"
+
+  stemcell_name="${stemcell_os}-${stemcell_version}"
+
+  echo -e "Building image:"
+  echo -e "  - Release name:    ${GREEN}${release_name}${NC}"
+  echo -e "  - Release version: ${GREEN}${release_version}${NC}"
+  echo -e "  - Release URL:     ${GREEN}${release_url}${NC}"
+  echo -e "  - Release SHA1:    ${GREEN}${release_sha1}${NC}"
+  echo -e "  - CF version:      ${GREEN}${cf_version}${NC}"
+  echo -e "  - Stemcell:        ${GREEN}${stemcell_name}${NC}"
+
+  # Build the release image.
+  fissile build release-images \
+    --stemcell="${stemcell_image}" \
+    --name="${release_name}" \
+    --version="${release_version}" \
+    --sha1="${release_sha1}" \
+    --url="${release_url}" \
+    --docker-organization="${docker_organization}"
+
+  # Check if there is an image already pushed for the release being built, otherwise push.
+  built_image_filter=$(docker images --format "{{.Repository}} {{.Tag}}" | grep "${release_name}.*${stemcell_name}.*${release_version}" | head -1)
+  built_image_repository=$(echo "${built_image_filter}" | awk '{ printf $1 }')
+  built_image_tag=$(echo "${built_image_filter}" | awk '{ printf $2 }')
+  built_image="${built_image_repository}:${built_image_tag}"
+  echo -e "Built image: ${GREEN}${built_image}${NC}"
+  if curl --head --fail "https://hub.docker.com/v2/repositories/${built_image_repository}/tags/${built_image_tag}/" 1> /dev/null 2> /dev/null; then
+    echo "Skipping push for ${GREEN}${built_image}${NC} as it is already present in the registry..."
+  else
+    docker push "${built_image}"
+  fi
+  docker rmi "${built_image}"
+
+  printf "----------------------------------------------------------------------------------------------------\n\n"
+}

--- a/pipelines/release-images-cf-deployment/vars.yml
+++ b/pipelines/release-images-cf-deployment/vars.yml
@@ -1,0 +1,12 @@
+ci-repo: https://github.com/cloudfoundry-incubator/cf-operator-ci
+ci-branch: master
+docker-image-resource-repo: https://github.com/concourse/docker-image-resource
+docker-image-resource-branch: master
+cf-deployment-repo: https://github.com/cloudfoundry/cf-deployment
+cf-deployment-branch: master
+cf-deployment-yaml: cf-deployment/cf-deployment.yml
+s3-bucket: cf-opensusefs2
+versions-s3-bucket: cf-operators
+stemcell-os: opensuse
+stemcell-repository: splatform/fissile-stemcell-opensuse
+docker-organization: cfcontainerization


### PR DESCRIPTION
The release-images-cf-deployment pipeline builds images using fissile
for all releases listed on the cf-deployment YAML files.

[166344111](https://www.pivotaltracker.com/story/show/166344111)