### PR TITLE
Add syslog release to pipeline

### DIFF
--- a/pipelines/release-images/pipeline.yml
+++ b/pipelines/release-images/pipeline.yml
@@ -1,5 +1,5 @@
 <%
-cloudfoundry_releases = %w(cf-mysql capi cf-networking cf-smoke-tests cf-syslog-drain cflinuxfs2 cflinuxfs3 diego garden-runc loggregator nats statsd-injector uaa loggregator-agent log-cache bosh-dns-aliases)
+cloudfoundry_releases = %w(cf-mysql capi cf-networking cf-smoke-tests cf-syslog-drain cflinuxfs2 cflinuxfs3 diego garden-runc loggregator nats statsd-injector uaa loggregator-agent log-cache bosh-dns-aliases syslog)
 incubator_releases = %w(bpm cf-routing pxc)
 bosh_packages_releases = %w(cf-cli)
 pivotal_cf_releases = %w(credhub)


### PR DESCRIPTION
- Syslog is being added so that BOSH pre-start hook tested in cf-operator as syslog is light release and has a pre-start script.