### PR TITLE
Refactoring cf-operator release images pipeline

### DIFF
--- a/pipelines/release-images-cf-deployment/pipeline.yml
+++ b/pipelines/release-images-cf-deployment/pipeline.yml
@@ -26,26 +26,27 @@ resources:
 - name: s3.fissile-linux
   type: s3
   source:
-    bucket: ((s3-bucket))
+    bucket: ((fissile-linux-s3-bucket))
     private: true
     regexp: fissile/develop/fissile-(.*)\.tgz
-- name: s3.fissile-stemcell-opensuse-version
+- name: s3.fissile-stemcell-version
   type: s3
   source:
-    bucket: ((versions-s3-bucket))
+    bucket: ((stemcell-versions-s3-bucket))
+    region_name: ((stemcell-s3-bucket-region))
     access_key_id: ((s3.accessKey))
     secret_access_key: ((s3.secretKey))
-    versioned_file: fissile-stemcell-versions/fissile-stemcell-opensuse-version
-
+    versioned_file: ((stemcell-version-file))
+    
 jobs:
 <% cf_deployment_tags.each do |cf_deployment_tag| %>
 - name: build-<%= cf_deployment_tag %>
   plan:
-  - aggregate:
+  - in_parallel:
     - get: ci
     - get: docker-image-resource
     - get: cf-deployment-<%= cf_deployment_tag %>
-    - get: s3.fissile-stemcell-opensuse-version
+    - get: s3.fissile-stemcell-version
       trigger: true
     - get: s3.fissile-linux
       trigger: true
@@ -53,12 +54,14 @@ jobs:
     - task: build
       privileged: true
       input_mapping:
-        s3.stemcell-version: s3.fissile-stemcell-opensuse-version
+        s3.stemcell-version: s3.fissile-stemcell-version
         cf-deployment: cf-deployment-<%= cf_deployment_tag %>
       params:
         STEMCELL_OS: ((stemcell-os))
         STEMCELL_REPOSITORY: ((stemcell-repository))
+        STEMCELL_VERSIONED_FILE: ((stemcell-version-file))
         CF_DEPLOYMENT_YAML: ((cf-deployment-yaml))
+        DOCKER_REGISTRY: ((docker-registry))
         DOCKER_ORGANIZATION: ((docker-organization))
         DOCKER_TEAM_USERNAME: ((dockerhub.username))
         DOCKER_TEAM_PASSWORD_RW: ((dockerhub.password))

--- a/pipelines/release-images-cf-deployment/tasks/build.sh
+++ b/pipelines/release-images-cf-deployment/tasks/build.sh
@@ -16,16 +16,16 @@ start_docker \
 trap 'stop_docker' EXIT
 
 # Login to the Docker registry.
-echo "${DOCKER_TEAM_PASSWORD_RW}" | docker login --username "${DOCKER_TEAM_USERNAME}" --password-stdin
+echo "${DOCKER_TEAM_PASSWORD_RW}" | docker login "${DOCKER_REGISTRY}" --username "${DOCKER_TEAM_USERNAME}" --password-stdin
 
 # Extract the fissile binary.
 tar xvf s3.fissile-linux/fissile-*.tgz --directory "/usr/local/bin/"
 
 # Pull the stemcell image.
-stemcell_version="$(cat s3.stemcell-version/*-version)"
+stemcell_version="$(cat s3.stemcell-version/"${STEMCELL_VERSIONED_FILE##*/}")"
 stemcell_image="${STEMCELL_REPOSITORY}:${stemcell_version}"
 docker pull "${stemcell_image}"
 
 # Build the releases.
 tasks_dir="$(dirname $0)"
-bash <(yq -r ".manifest_version as \$cf_version | .releases[] | \"source ${tasks_dir}/build_release.sh; build_release \\(\$cf_version|@sh) '${DOCKER_ORGANIZATION}' '${STEMCELL_OS}' '${stemcell_version}' '${stemcell_image}' \\(.name|@sh) \\(.url|@sh) \\(.version|@sh) \\(.sha1|@sh)\"" "${CF_DEPLOYMENT_YAML}")
+bash <(yq -r ".manifest_version as \$cf_version | .releases[] | \"source ${tasks_dir}/build_release.sh; build_release \\(\$cf_version|@sh) '${DOCKER_REGISTRY}' '${DOCKER_ORGANIZATION}' '${DOCKER_TEAM_USERNAME}' '${DOCKER_TEAM_PASSWORD_RW}' '${STEMCELL_OS}' '${stemcell_version}' '${stemcell_image}' \\(.name|@sh) \\(.url|@sh) \\(.version|@sh) \\(.sha1|@sh)\"" "${CF_DEPLOYMENT_YAML}")

--- a/pipelines/release-images-cf-deployment/vars.yml
+++ b/pipelines/release-images-cf-deployment/vars.yml
@@ -5,8 +5,11 @@ docker-image-resource-branch: master
 cf-deployment-repo: https://github.com/cloudfoundry/cf-deployment
 cf-deployment-branch: master
 cf-deployment-yaml: cf-deployment/cf-deployment.yml
-s3-bucket: cf-opensusefs2
-versions-s3-bucket: cf-operators
+fissile-linux-s3-bucket: cf-opensusefs2
 stemcell-os: opensuse
 stemcell-repository: splatform/fissile-stemcell-opensuse
+stemcell-versions-s3-bucket: cf-operators
+stemcell-version-file: fissile-stemcell-versions/fissile-stemcell-opensuse-version
+stemcell-s3-bucket-region: us-east-1
+docker-registry: docker.io
 docker-organization: cfcontainerization


### PR DESCRIPTION
### Description:

The current release images concourse pipeline for building `cf-operator` release images is heavily based on `opensuse`. This PR intends to make it more generic so that it can be used to build images using alternative stemcells such as `SLE`.

Here is a list of major changes:
  - make pipeline more configurable to accomodate `SLE`
  - use better naming conventions
  - improvements and bug fixes 