### PR TITLE
Based on card 167509287

### DIFF
--- a/dockerfiles/go-tools/Dockerfile
+++ b/dockerfiles/go-tools/Dockerfile
@@ -19,6 +19,8 @@ RUN go get honnef.co/go/tools/cmd/staticcheck && cd $GOPATH/src/honnef.co/go/too
 
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl; mv kubectl /usr/local/bin; chmod +x /usr/local/bin/kubectl
 
+RUN curl -sL https://raw.githubusercontent.com/homeport/havener/master/scripts/download-latest.sh | bash
+
 RUN curl -fsL https://clis.ng.bluemix.net/install/linux | sh && \
     bx plugin install container-service -r Bluemix && \
     bx plugin install container-registry -r Bluemix && \


### PR DESCRIPTION
[167509287](https://www.pivotaltracker.com/story/show/167509287) 

This is about nuking the docker images in the kube nodes, while when we pile too many images in the nodes, this seems to be reflected in the cluster performance, e.g. slow statefulset controller, leading to timeouts in out CI tests.