### PR TITLE
Release images pipeline improvements

### DIFF
--- a/pipelines/release-images-cf-deployment/pipeline.yml
+++ b/pipelines/release-images-cf-deployment/pipeline.yml
@@ -1,7 +1,7 @@
 # This pipeline will setup the build for all the cf_deployment_releases specified below.
 
 <%
-cf_deployment_tags = %w(v7.11.0 v8.0.0 v8.1.0 v9.0.0 v9.2.0)
+cf_deployment_tags = %w(v8.0.0 v9.2.0 v9.5.0)%>
 %>
 
 resources:

--- a/pipelines/release-images-cf-deployment/tasks/build_release.sh
+++ b/pipelines/release-images-cf-deployment/tasks/build_release.sh
@@ -27,17 +27,17 @@ function build_release() {
   echo -e "  - Release URL:     ${GREEN}${release_url}${NC}"
   echo -e "  - Release SHA1:    ${GREEN}${release_sha1}${NC}"
 
-  # Dry run fissile just to print image name.
-  built_image="$(fissile build release-images \
-    --stemcell="${stemcell_image}" \
-    --name="${release_name}" \
-    --version="${release_version}" \
-    --sha1="${release_sha1}" \
-    --url="${release_url}" \
-    --docker-registry="${docker_registry}" \
-    --docker-organization="${docker_organization}" \
-    --dry-run | cut -d' ' -f3)"
+  build_args=(
+    --stemcell="${stemcell_image}"
+    --name="${release_name}"
+    --version="${release_version}"
+    --sha1="${release_sha1}"
+    --url="${release_url}"
+    --docker-registry="${docker_registry}"
+    --docker-organization="${docker_organization}"
+  )
 
+  built_image=$(fissile build release-images --dry-run "${build_args[@]}" | cut -d' ' -f3)
   built_image_tag="${built_image#*:}"
   docker_creds_string=""${docker_username}":"${docker_password}""
 
@@ -46,14 +46,7 @@ function build_release() {
     echo -e "Skipping push for ${GREEN}${built_image}${NC} as it is already present in the registry..."
   else
       # Build the release image.
-      fissile build release-images \
-        --stemcell="${stemcell_image}" \
-        --name="${release_name}" \
-        --version="${release_version}" \
-        --sha1="${release_sha1}" \
-        --url="${release_url}" \
-        --docker-registry="${docker_registry}" \
-        --docker-organization="${docker_organization}"
+      fissile build release-images "${build_args[@]}"
 
       echo -e "Built image: ${GREEN}${built_image}${NC}"
       docker push "${built_image}"

--- a/pipelines/release-images-cf-deployment/tasks/build_release.sh
+++ b/pipelines/release-images-cf-deployment/tasks/build_release.sh
@@ -21,37 +21,44 @@ function build_release() {
 
   stemcell_name="${stemcell_os}-${stemcell_version}"
 
-  echo -e "Building image:"
+  echo -e "Release information:"
   echo -e "  - Release name:    ${GREEN}${release_name}${NC}"
   echo -e "  - Release version: ${GREEN}${release_version}${NC}"
   echo -e "  - Release URL:     ${GREEN}${release_url}${NC}"
   echo -e "  - Release SHA1:    ${GREEN}${release_sha1}${NC}"
-  echo -e "  - CF version:      ${GREEN}${cf_version}${NC}"
-  echo -e "  - Stemcell:        ${GREEN}${stemcell_name}${NC}"
 
-  # Build the release image.
-  fissile build release-images \
+  # Dry run fissile just to print image name.
+  built_image="$(fissile build release-images \
     --stemcell="${stemcell_image}" \
     --name="${release_name}" \
     --version="${release_version}" \
     --sha1="${release_sha1}" \
     --url="${release_url}" \
     --docker-registry="${docker_registry}" \
-    --docker-organization="${docker_organization}"
+    --docker-organization="${docker_organization}" \
+    --dry-run | cut -d' ' -f3)"
+
+  built_image_tag="${built_image#*:}"
+  docker_creds_string=""${docker_username}":"${docker_password}""
 
   # Check if there is an image already pushed for the release being built, otherwise push.
-  built_image_filter=$(docker images --format "{{.Repository}} {{.Tag}}" | grep "${release_name}.*${stemcell_name}.*${release_version}" | head -1)
-  built_image_repository=$(echo "${built_image_filter}" | awk '{ printf $1 }')
-  built_image_tag=$(echo "${built_image_filter}" | awk '{ printf $2 }')
-  built_image="${built_image_repository}:${built_image_tag}"
-  echo -e "Built image: ${GREEN}${built_image}${NC}"
-  docker_creds_string=""${docker_username}":"${docker_password}""
   if curl --silent -u "${docker_creds_string}" "https://"${docker_registry}"/v2/"${docker_organization}"/"${release_name}"/manifests/"${built_image_tag}"" | jq '.errors[0].code' | grep -q null; then
     echo -e "Skipping push for ${GREEN}${built_image}${NC} as it is already present in the registry..."
   else
-    docker push "${built_image}"
+      # Build the release image.
+      fissile build release-images \
+        --stemcell="${stemcell_image}" \
+        --name="${release_name}" \
+        --version="${release_version}" \
+        --sha1="${release_sha1}" \
+        --url="${release_url}" \
+        --docker-registry="${docker_registry}" \
+        --docker-organization="${docker_organization}"
+
+      echo -e "Built image: ${GREEN}${built_image}${NC}"
+      docker push "${built_image}"
+      docker rmi "${built_image}"
   fi
-  docker rmi "${built_image}"
 
   echo '----------------------------------------------------------------------------------------------------'
 }


### PR DESCRIPTION
This PR is to use newly introduced `--dry-run` flag in `fissile build` in order to skip the build step for already published images.

Link to fissile PR: https://github.com/cloudfoundry-incubator/fissile/pull/509