### PR TITLE
Kubeconfig SSL no longer needs fixing

### DIFF
--- a/pipelines/tasks/test-integration.sh
+++ b/pipelines/tasks/test-integration.sh
@@ -81,7 +81,4 @@ fi
 
 echo "--------------------------------------------------------------------------------"
 echo "Running e2e CLI tests"
-# fix relative SSL path in KUBECONFIG
-kube_path=$(dirname "$KUBECONFIG")
-sed -i 's@certificate-authority: \(.*\)$@certificate-authority: '$kube_path'/\1@' "$KUBECONFIG"
 make -C src/code.cloudfoundry.org/cf-operator test-cli-e2e


### PR DESCRIPTION
Since the new ibmcloud tools use the kubectl context instead of setting
KUBECONFIG we no longer need to fix the SSL cert path