### PR TITLE
Remove unused commands from test-helm-e2e

### DIFF
--- a/pipelines/tasks/test-helm-e2e.sh
+++ b/pipelines/tasks/test-helm-e2e.sh
@@ -9,33 +9,24 @@ set -eux
 : "${ibmcloud_server:?}"
 : "${ibmcloud_region:?}"
 : "${ibmcloud_cluster:?}"
-: "${ssh_server_ip:?}"
-: "${ssh_server_user:?}"
-: "${ssh_server_key:?}"
 : "${OPERATOR_TEST_STORAGE_CLASS:?}"
 : "${DOCKER_IMAGE_REPOSITORY:?}"
 
 export PATH=$PATH:$PWD/bin
 export GOPATH=$PWD
-export GO111MODULE=on
 export TEST_NAMESPACE="test$(date +%s)"
-
-# Random port to support parallelism with different webhook servers
-export CF_OPERATOR_WEBHOOK_SERVICE_PORT=$(( ( RANDOM % 2000 )  + 2000 ))
-export TUNNEL_NAME="tunnelpod-${CF_OPERATOR_WEBHOOK_SERVICE_PORT}"
 
 upload_debug_info() {
   if ls /tmp/env_dumps/* &> /dev/null; then
     TARBALL_NAME="env_dump-$(date +"%s").tar.gz"
     echo "Env dumps will be uploaded as ${TARBALL_NAME}"
-    tar cfzv env_dumps/${TARBALL_NAME} -C /tmp/env_dumps/ .
+    tar cfzv env_dumps/"$TARBALL_NAME" -C /tmp/env_dumps/ .
   fi
 }
 
 ## Make sure to cleanup the tunnel pod and service
 cleanup () {
   upload_debug_info
-  pidof ssh | xargs kill
 }
 trap cleanup EXIT
 
@@ -45,38 +36,6 @@ export BLUEMIX_CS_TIMEOUT=500
 ibmcloud ks cluster config --cluster "$ibmcloud_cluster"
 
 echo "Running e2e tests in the ${ibmcloud_cluster} cluster."
-
-echo "Creating namespace"
-kubectl create namespace "$TEST_NAMESPACE"
-
-echo "The cf-operator will be installed into the ${TEST_NAMESPACE} namespace."
-
-echo "Setting up SSH tunnel for webhook"
-cat <<EOF > identity
-$ssh_server_key
-EOF
-chmod 0600 identity
-
-# GatewayPorts option needs to be enabled on ssh server
-ssh -fNT -i identity -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -R "${ssh_server_ip}:${CF_OPERATOR_WEBHOOK_SERVICE_PORT}:localhost:${CF_OPERATOR_WEBHOOK_SERVICE_PORT}" "${ssh_server_user}@${ssh_server_ip}"
-
-echo "Setting up webhook on k8s"
-cat <<EOF | kubectl create -f - --namespace=${TEST_NAMESPACE}
----
-kind: Endpoints
-apiVersion: v1
-metadata:
-  name: ${TUNNEL_NAME}
-subsets:
-  - addresses:
-      - ip: ${ssh_server_ip}
-    ports:
-      - port: ${CF_OPERATOR_WEBHOOK_SERVICE_PORT}
-EOF
-export CF_OPERATOR_WEBHOOK_SERVICE_HOST="$ssh_server_ip"
-
-
-echo "Running e2e tests with helm"
 echo "--------------------------------------------------------------------------------"
 make -C src/code.cloudfoundry.org/cf-operator test-helm-e2e
 


### PR DESCRIPTION
Operator is installed via helm and runs in-cluster, the tunnel is not
used.

Test: https://ci.flintstone.cf.cloud.ibm.com/teams/quarks/pipelines/mm-test/jobs/test-integration/builds/2